### PR TITLE
Disable annoying redefinition warnings

### DIFF
--- a/lib/logfilter.ex
+++ b/lib/logfilter.ex
@@ -76,6 +76,8 @@ defmodule Log do
       <> filter_defs <> "\n"
       <> "  def filter(_, _), do: false\n"
       <> "end"
+
+    Code.compiler_options(ignore_module_conflict: true)
     Code.compile_string(module_def)
     :ok
   end


### PR DESCRIPTION
This disables stderr warnings when the filter is updated:

```
nofile:1: warning: redefining module LogFilter
```
